### PR TITLE
Fix - Disabled SSL enforcement

### DIFF
--- a/terraform/modules/my_sql/main.tf
+++ b/terraform/modules/my_sql/main.tf
@@ -48,8 +48,8 @@ resource "azurerm_mysql_server" "mysql" {
   geo_redundant_backup_enabled      = false
   infrastructure_encryption_enabled = false
   public_network_access_enabled     = false
-  ssl_enforcement_enabled           = true
-  ssl_minimal_tls_version_enforced  = "TLS1_2"
+  ssl_enforcement_enabled           = false
+  #ssl_minimal_tls_version_enforced  = "TLS1_2"
 
   timeouts {
       create = "60m"


### PR DESCRIPTION
Disabled SSL enforcement to allow the pet clinic app to work.