### PR TITLE
Modified - Modified REAMDE.md for ARM to correct Azure Firewall extension name

### DIFF
--- a/ARM/README.md
+++ b/ARM/README.md
@@ -8,7 +8,7 @@
 
 2. Run the two commands below to add the required extensions to Azure CLI.
 
-    `az extension add --name firewall`
+    `az extension add --name azure-firewall`
 
     `az extension add --name spring-cloud`
 


### PR DESCRIPTION
Incorrectly had Azure CLI extension for Azure Firewall named "firewall". Corrected this to be named "azure-firewall".