### PR TITLE
Fix - Correcting missing environment variable path for maven

### DIFF
--- a/deployPetClinicApp.ps1
+++ b/deployPetClinicApp.ps1
@@ -19,7 +19,7 @@ cd c:\source-code
 #Clone GitHub Repo
 git clone https://github.com/azure-samples/spring-petclinic-microservices
 cd spring-petclinic-microservices
-mvn clean package -DskipTests -Denv=cloud
+C:\ProgramData\chocolatey\lib\maven\apache-maven-3.6.3\bin\mvn clean package -DskipTests -Denv=cloud
 
 # ==== Service and App Instances ====
 $API_GATEWAY='api-gateway'


### PR DESCRIPTION
Fixing error when running maven:  mvn clean package -DskipTests -Denv=cloud
+ ~~~
    + CategoryInfo          : ObjectNotFound: (mvn:String) [], CommandNotFoundException
    + FullyQualifiedErrorId : CommandNotFoundException