### PR TITLE
Fix/jump box password env var

### DIFF
--- a/Scenarios/ASA-Secure-Baseline/Terraform/04-LZ-SharedResources.md
+++ b/Scenarios/ASA-Secure-Baseline/Terraform/04-LZ-SharedResources.md
@@ -59,10 +59,10 @@ terraform init -backend-config="resource_group_name=$TFSTATE_RG" -backend-config
 
 ```bash
 # If using PowerShell
-$ENV:TF_VAR_JUMP_HOST_PASSWORD="xxxxx"
+$ENV:TF_VAR_jump_host_password="xxxxx"
 
 # If using Bash
-export TF_VAR_JUMP_HOST_PASSWORD="xxxxx"
+export TF_VAR_jump_host_password="xxxxx"
 
 # Then proceed to the plan step
 terraform plan -out my.plan --var-file ../parameters.tfvars

--- a/Scenarios/ASA-Secure-Baseline/Terraform/04-LZ-SharedResources.md
+++ b/Scenarios/ASA-Secure-Baseline/Terraform/04-LZ-SharedResources.md
@@ -59,10 +59,10 @@ terraform init -backend-config="resource_group_name=$TFSTATE_RG" -backend-config
 
 ```bash
 # If using PowerShell
-$ENV:TF_VAR_JUMP_HOST_PASS="xxxxx"
+$ENV:TF_VAR_JUMP_HOST_PASSWORD="xxxxx"
 
 # If using Bash
-export TF_VAR_JUMP_HOST_PASS="xxxxx"
+export TF_VAR_JUMP_HOST_PASSWORD="xxxxx"
 
 # Then proceed to the plan step
 terraform plan -out my.plan --var-file ../parameters.tfvars


### PR DESCRIPTION
The name of the environment variable should be TF_VAR_<var_name>. In `04-LZ-SharedResources/main.tf`, we have:
jumphost_pass            = ( var.jump_host_password == "" ? random_password.jumphostpass.result : var.jump_host_password )

The variable name needs to be identical (some OS are case sensitive).