### PR TITLE
Modiy azuredeploySpringEnterprise.sh

### DIFF
--- a/archive/CLI/brownfield-deployment/azuredeploySpringEnterprise.sh
+++ b/archive/CLI/brownfield-deployment/azuredeploySpringEnterprise.sh
@@ -8,7 +8,7 @@ echo "Enter Azure region for resource deployment: "
 read region
 location=$region
 
-echo "Enter Azure Spring  Resource Group Name: "
+echo "Enter Azure Spring Resource Group Name: "
 read azurespringrg
 azurespring_resource_group_name=$azurespringrg
 
@@ -32,7 +32,7 @@ echo "Enter Azure Log Analytics Workspace Resource Group Name: "
 read loganalyticsrg
 loganalyticsrg=$loganalyticsrg
 
-echo "Enter Log Analytics Workspace Resource ID: "
+echo "Enter Log Analytics Workspace Resource Name: "
 read workspace
 workspaceID='/subscriptions/'$subscription'/resourcegroups/'$loganalyticsrg'/providers/microsoft.operationalinsights/workspaces/'$workspace
 

--- a/archive/CLI/brownfield-deployment/azuredeploySpringEnterprise.sh
+++ b/archive/CLI/brownfield-deployment/azuredeploySpringEnterprise.sh
@@ -69,7 +69,6 @@ az spring create \
     --enable-gateway \
     --enable-api-portal \
     --api-portal-instance-count 2 \
-    --enable-java-agent true \
     --app-insights ${azurespring_service} \
     --app-subnet ${azurespring_app_subnet_name} \
     --service-runtime-subnet ${azurespring_service_subnet_name} \

--- a/archive/CLI/brownfield-deployment/azuredeploySpringStandard.sh
+++ b/archive/CLI/brownfield-deployment/azuredeploySpringStandard.sh
@@ -8,7 +8,7 @@ echo "Enter Azure region for resource deployment: "
 read region
 location=$region
 
-echo "Enter Azure Spring  Resource Group Name: "
+echo "Enter Azure Spring Resource Group Name: "
 read azurespringrg
 azurespring_resource_group_name=$azurespringrg
 


### PR DESCRIPTION
Fix some small errors
- move duplicate space
- Fix error text from `Workspace Resource ID` to `Workspace Resource Name`
- remove `--enable-java-agent true`

The public doc refer to these bash scripts and we want to fix some small errors in this doc:
https://learn.microsoft.com/en-us/azure/spring-apps/quickstart-deploy-infrastructure-vnet-azure-cli?tabs=azure-spring-apps-enterprise